### PR TITLE
fix transaction size issue caused by embedded relationships

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stix2arango"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   { name = "dogesec" }
 ]


### PR DESCRIPTION
An object can have as many embedded refs as possible, this makes it possible that there's way too many data to upload in a single transaction which will cause a failure due to memory limit as occured in [this run](https://github.com/muchdogesec/ctibutler/actions/runs/16215327814/job/45783337984#step:7:2336)